### PR TITLE
XAMPP Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM docker.io/centos:7.3.1611
-LABEL maintainer "Apache Friends"
-ARG IB_VERSION=22.3.0
+FROM ubuntu:24.04
+LABEL maintainer="Apache Friends"
+ARG IB_VERSION=24.7.0
 
-# Compilation tools
-RUN yum install -y \
-ca-certificates file m4 gcc gcc-c++ make perl patch unzip bzip2 epel-release \
-&& yum install -y p7zip p7zip-plugins \
-&& yum clean all
+# Install necessary tools and dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates file m4 gcc g++ make perl patch unzip bzip2 curl \
+    p7zip-full p7zip-rar tcl tk tcllib itcl3 tcl-vfs tdom \
+    && apt-get clean
 
-RUN curl > 'tclkit' 'https://tclkits.rkeene.org/fossil/raw/tclkit-8.5.17-rhel5-x86_64?name=76a197fe41359daaf4f90a2001f46675b3667e26' \
-&& chmod 755 tclkit && mv tclkit /usr/local/bin
+# Download and install InstallBuilder
+RUN curl -L -o installbuilder.run "https://releases.installbuilder.com/installbuilder/installbuilder-enterprise-${IB_VERSION}-linux-x64-installer.run" \
+    && chmod 755 installbuilder.run \
+    && ./installbuilder.run --mode unattended --prefix /opt/installbuilder \
+    && rm installbuilder.run \
+    && ln -sf /opt/installbuilder /root/installbuilder-${IB_VERSION}
 
-RUN curl -L > 'installbuilder.run' "https://installbuilder.com/installbuilder-professional-${IB_VERSION}-linux-x64-installer.run" \
-&& chmod 755 installbuilder.run && ./installbuilder.run --mode unattended --prefix /opt/installbuilder \
-&& rm installbuilder.run && ln -sf /opt/installbuilder /root/installbuilder-${IB_VERSION}
-
-CMD [ "bash" ]
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 LABEL maintainer="Apache Friends"
-ARG IB_VERSION=24.7.0
+ARG IB_VERSION=25.6.0
 
 # Install necessary tools and dependencies
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ You can build the XAMPP base tarballs from the `src` directory. You can get the 
 Once the needed files are located into a `tarballs` directory and mounted into the container at `/tmp/tarballs`, your can run the commands below to create the desired installer depending on the platform. You can use the container to compile the binaries for Linux x64 but you will need access to an OS X higher than 10.6 to compile the binaries from OS X there.
 
 ```
-tclkit createstack.tcl buildTarball xamppunixinstaller80stack linux-x64
-tclkit createstack.tcl buildTarball xamppunixinstaller80stack osx-x64
+tclsh createstack.tcl buildTarball xamppunixinstaller80stack linux-x64
+tclsh createstack.tcl buildTarball xamppunixinstaller80stack osx-x64
 ```
 
-> NOTE: you can build other PHP versions (7.4.x, 8.0.x, or 8.1.x) replacing `80` with `74` or `81`.
+> NOTE: you can build other PHP versions (7.4.x, 8.0.x, 8.1.x, or 8.2.x) replacing `80` with `74`, `81`, or `82`.
 
 Once the tarball is compressed, you can move it to the `/tmp/tarball` mounted directory to use it in the next step.
 
@@ -40,12 +40,12 @@ You can build the XAMPP installers from the `src` directory. The Linux and OS X 
 Once the needed files are located into a `tarballs` directory and mounted into the container at `/tmp/tarballs`, your can run the commands below to create the desired installer depending on the platform.
 
 ```
-tclkit createstack.tcl pack xamppunixinstaller80stack linux-x64
-tclkit createstack.tcl pack xamppunixinstaller80stack osx-x64
-tclkit createstack.tcl pack xamppinstaller80stack windows-x64
+tclsh createstack.tcl pack xamppunixinstaller80stack linux-x64
+tclsh createstack.tcl pack xamppunixinstaller80stack osx-x64
+tclsh createstack.tcl pack xamppinstaller80stack windows-x64
 ```
 
-> NOTE: you can pack other PHP versions (7.4.x, 8.0.x, or 8.1.x) replacing `80` with `74` or `81`.
+> NOTE: you can pack other PHP versions (7.4.x, 8.0.x, 8.1.x, or 8.2.x) replacing `80` with `74`, `81`, or `82`.
 
 The installers will be accessible at `/opt/installbuilder/output/`.
 

--- a/src/util.tcl
+++ b/src/util.tcl
@@ -770,7 +770,7 @@ proc buildProgram {p be} {
 }
 
 proc buildProject {project be buildType {license {}} {extraSetVars {}} {onlyGenerateScript 0}} {
-    set IBversion [findInstallBuilderVersion $be]
+    set IBversion 24.7.0
     populateEmptyDirs [file dirname $project]
     message info "Building installer with IB version $IBversion"
     if {[info exists ::env(BITNAMI_AUTOMATIC_BUILD)]} {
@@ -949,15 +949,6 @@ proc includeLibGcc {be {destination {}}} {
     }
 }
 
-proc findInstallBuilderVersion {be} {
-    if {[catch {set file [open [file join [$be cget -projectDir] src ibversion] r]}]} {
-	message error "'ibversion' file couldn't be found in [$be cget -projectDir]/src"
-	exit 1
-    }
-    set ibversion [gets $file]
-    close $file
-    return $ibversion
-}
 proc populateEmptyDirs {directory} {
     # The reason is that when the customers uncompress the files we send to them
     # for building on their side, some Winzip utilities would ignore by default

--- a/src/util.tcl
+++ b/src/util.tcl
@@ -770,7 +770,7 @@ proc buildProgram {p be} {
 }
 
 proc buildProject {project be buildType {license {}} {extraSetVars {}} {onlyGenerateScript 0}} {
-    set IBversion 24.7.0
+    set IBversion 25.6.0
     populateEmptyDirs [file dirname $project]
     message info "Building installer with IB version $IBversion"
     if {[info exists ::env(BITNAMI_AUTOMATIC_BUILD)]} {


### PR DESCRIPTION
- Updated Docker to replace the broken InstallBuilder link, use a non deprecated image (Ubuntu), and use tcl (tclsh) instead of tclkit for the build process.
- Updated the README.md to include mention of PHP 8.2 and to reflect the transition to tclsh.
- Hardcoded the IBversion because the code to dynamically grab it was trying to get it from a non existent file.