### PR TITLE
Upgrade bundled stack defaults and refresh dependency versions

### DIFF
--- a/metadata/versions/versions.ini
+++ b/metadata/versions/versions.ini
@@ -14,8 +14,8 @@ portable=5.42.2.1
 [PHP]
 74=7.4.33
 80=8.0.30
-81=8.1.33
-82=8.2.29
+81=8.1.34
+82=8.2.30
 83=8.3.30
 84=8.4.20
 85=8.5.5
@@ -23,8 +23,8 @@ portable=5.42.2.1
 # Servers
 #
 [Apache]
-stable=2.4.65
-windows=2.4.65
+stable=2.4.66
+windows=2.4.66
 [Memcached]
 stable=1.6.39
 [Subversion]
@@ -44,7 +44,8 @@ stable=6.0.10
 #
 [MariaDB]
 10=10.11.16
-11=11.8.4
+11=11.8.6
+12=12.2.2
 [MySQL]
 55=5.5.62
 56=5.6.51
@@ -58,7 +59,7 @@ stable=6.0.10
 17=17.6
 18=18.0
 [SQLite]
-stable=3.51.0
+stable=3.51.3
 #
 # Connectors
 #
@@ -73,13 +74,13 @@ stable=42.7.8
 # Others
 #
 [Curl]
-stable=8.17.0
+stable=8.19.0
 [GDAL]
 stable=3.4.3
 [Geos]
 stable=3.10.3
 [Git]
-stable=2.51.2
+stable=2.54.0
 [OpenLDAP]
 stable=2.6.10
 [PortableGit]
@@ -88,7 +89,7 @@ stable=2.51.2
 [ICU4C]
 stable=66.1
 [OpenSSL]
-stable=3.5.3
+stable=3.5.6
 [PageSpeed]
 stable=1.13.35.2-r0
 [Proj]

--- a/src/apache.tcl
+++ b/src/apache.tcl
@@ -82,12 +82,12 @@
         set dependencies {openssl {openssl-functions.xml openssl.xml openssl-without-apache.xml}}
         set readmePlaceholder OPENSSL
         set downloadType wget
-        set downloadUrl http://www.openssl.org/source/openssl-$version.tar.gz
+        set downloadUrl https://www.openssl.org/source/openssl-$version.tar.gz
     }
     public method download {} {
         set version  [getVersionFromVtracker]
         set downloadType wget
-        set downloadUrl http://www.openssl.org/source/openssl-$version.tar.gz
+        set downloadUrl https://www.openssl.org/source/openssl-$version.tar.gz
         chain
     }
     public method prefix {} {
@@ -151,7 +151,7 @@
     } {
         set supportsParallelBuild 0   ;# Apparently only FreeBSD stuff. But its better to disable it on all platforms
         set licenseRelativePath LICENSE
-        set licenseNotes http://www.openssl.org/source/license.html
+        set licenseNotes https://www.openssl.org/source/license.html
     }
     public method getPatchesToApply {} {
         if { [$be cget -target] == "osx-x64" && [::xampptcl::util::compareVersions $version 1.0.2g] == 0 } {
@@ -217,7 +217,7 @@
         # https://www.openssl.org/docs/man1.1.1/man1/openssl-rand.html
         exec [prefix]/bin/openssl rand -out [file join [rndFileInstallDir] .rnd] [expr {int(rand()*1000)}]
         if { ![file exists [file join [rndFileInstallDir] .rnd]] } {
-            message error "seeding file not found - http://www.openssl.org/support/faq.html#USER1"
+            message error "seeding file not found - https://www.openssl.org/support/faq.html#USER1"
         }
 
         file rename -force [prefix]/bin/openssl [prefix]/bin/openssl.bin

--- a/src/mysql.tcl
+++ b/src/mysql.tcl
@@ -328,9 +328,9 @@ mysqld_ld_library_path=@@XAMPP_MYSQL_ROOTDIR@@/lib}]
         set osxVersion $version
         regexp -- {^(.*\..*)\..*$} $version - urlFolder
         if {[$be cget -target] == "linux"} {
-            set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-i686.tar.gz
+            set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-i686.tar.gz
         } else {
-            set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-x86_64.tar.gz
+            set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-x86_64.tar.gz
         }
     }
     public method getTarballName {} {
@@ -353,9 +353,9 @@ mysqld_ld_library_path=@@XAMPP_MYSQL_ROOTDIR@@/lib}]
         set osxVersion $version
         regexp -- {^(.*\..*)\..*$} $version - urlFolder
         if {[$be cget -target] == "linux"} {
-            set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-i686.tar.gz
+            set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-i686.tar.gz
         } else {
-            set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-x86_64.tar.gz
+            set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-x86_64.tar.gz
         }
     }
 }
@@ -369,9 +369,9 @@ mysqld_ld_library_path=@@XAMPP_MYSQL_ROOTDIR@@/lib}]
         set licenseRelativePath LICENSE
         regexp -- {^(.*\..*)\..*$} $version - urlFolder
         if {[$be cget -target] == "linux"} {
-            set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-i686.tar.gz
+            set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-i686.tar.gz
         } else {
-            set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-x86_64.tar.gz
+            set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-linux-glibc2.12-x86_64.tar.gz
         }
     }
     public method preparefordist {} {
@@ -463,7 +463,7 @@ mysqld_ld_library_path=@@XAMPP_MYSQL_ROOTDIR@@/lib}]
     constructor {environment} {
         chain $environment
     } {
-        set version [versions::get "MariaDB" 10]
+        set version [versions::get "MariaDB" 12]
         set osxVersion $version
         regexp -- {^(.*\..*)\..*$} $version - urlFolder
     }
@@ -688,7 +688,7 @@ no-auto-rehash
        chain $environment
     } {
         set version [versions::get "MySQL" 56]
-        set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-winx64.zip
+        set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-winx64.zip
     }
     public method getTarballName {} {
         return mysql-${version}-winx64
@@ -740,7 +740,7 @@ no-auto-rehash
        chain $environment
     } {
         set version [versions::get "MySQL" 57]
-        set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-winx64.zip
+        set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-winx64.zip
     }
 }
 
@@ -751,7 +751,7 @@ no-auto-rehash
     } {
         set version [versions::get "MySQL" 80]
         set licenseRelativePath LICENSE
-        set downloadUrl http://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-winx64.zip
+        set downloadUrl https://dev.mysql.com/get/Downloads/MySQL-${urlFolder}/mysql-${version}-winx64.zip
         lappend additionalFileList vcruntime140_1.dll
     }
      public method preparefordist {} {
@@ -773,7 +773,7 @@ no-auto-rehash
         set uniqueIdentifier mariadb
         set readmePlaceholder MARIADB
         set licenseRelativePath COPYING
-        set version [versions::get "MariaDB" 10]
+        set version [versions::get "MariaDB" 12]
         $be configure -setvars "[$be cget -setvars] mysql_database_type=MariaDB"
         lappend additionalFileList vcruntime140_1.dll
     }
@@ -899,7 +899,7 @@ no-auto-rehash
         chain $environment
     } {
         set name mariadb
-        set version [versions::get "MariaDB" 10]
+        set version [versions::get "MariaDB" 12]
         set supportsParallelBuild 0
         set patchList {TokuDB-MacOS.patch mariadb-clock_realtime.patch}
     }

--- a/src/php.tcl
+++ b/src/php.tcl
@@ -82,7 +82,7 @@ proc pearProgram {name args} {
         lappend additionalFileList vcredist_x64_2008.exe vcredist_x64_2012.exe vcredist_x64_2015.exe vcredist_x64_2017.exe vcredist_x64_2019.exe vcredist_x64_2022.exe lamp56.tar.gz php/php5apache2_4.dll composer-$composerVersion.phar composer-license.txt windowstools/vcredist/msvcr110.dll windowstools/vcredist/msvcp110.dll
     }
     public method extractDirectory {} {
-        if { [string match *Win32-VC6-x* $tarballName] || [string match *Win32-VC9-x* $tarballName] || [string match *Win32-VC1\[145\]-x* $tarballName] || [string match *Win32-VS1\[6\]-x* $tarballName]} {
+        if { [string match *Win32-VC6-x* $tarballName] || [string match *Win32-VC9-x* $tarballName] || [string match *Win32-VC1\[145\]-x* $tarballName] || [string match *Win32-VS1\[6\]-x* $tarballName] || [string match *Win32-vs16-x* $tarballName] || [string match *Win32-VS16-x* $tarballName] || [string match *Win32-vs17-x* $tarballName] || [string match *Win32-VS17-x* $tarballName]} {
             return [srcdir]
         } else {
             return [$be cget -src]

--- a/src/xampp-components.tcl
+++ b/src/xampp-components.tcl
@@ -1651,7 +1651,7 @@ UseFtpUsers}]
             set version 2.8.17
             set readmePlaceholder SQLITE
             set licenseRelativePath {}
-            set licenseNotes http://www.sqlite.org/copyright.html
+            set licenseNotes https://www.sqlite.org/copyright.html
 
         }
         public method setEnvironment {} {
@@ -1702,7 +1702,7 @@ UseFtpUsers}]
             }
             set tarballVersion "${majorVersion}${tailVersion}00"
             set tarballName "${name}-autoconf-${tarballVersion}"
-            set licenseNotes http://www.sqlite.org/copyright.html
+            set licenseNotes https://www.sqlite.org/copyright.html
 
         }
         public method setEnvironment {} {
@@ -1828,7 +1828,7 @@ UseFtpUsers}]
         } {
             set name "mariadb"
             set fullname MariaDB
-            set version [versions::get "MariaDB" "10"]
+            set version [versions::get "MariaDB" "12"]
             if {[$be targetPlatform] == "osx-x64"} {
                 set patchList {TokuDB-MacOS.patch mariadb-clock_realtime.patch}
             }
@@ -2527,7 +2527,7 @@ $cfg['Servers'][$i]['favorite'] = 'pma__favorite';} \
         } {
             set name "php"
             set fullname PHP
-            set version [::xampp::php::getXAMPPVersion 74]
+            set version [::xampp::php::getXAMPPVersion 85]
             set licenseRelativePath LICENSE
             set supportsParallelBuild 0
         }
@@ -2604,10 +2604,10 @@ $cfg['Servers'][$i]['favorite'] = 'pma__favorite';} \
             #Avoid php 5.4.25 download install-pear-nozlib.phar
             if {[::xampptcl::util::compareVersions $version 7.4.0] < 0} {
                 xampptcl::util::substituteParametersInFile [file join [srcdir] makedist]  \
-                    [list {wget http://pear.php.net/install-pear-nozlib.phar -nd -P pear/} {ls pear/install-pear-nozlib.phar}]
+                    [list {wget https://pear.php.net/install-pear-nozlib.phar -nd -P pear/} {ls pear/install-pear-nozlib.phar}]
             }  else {
                 xampptcl::util::substituteParametersInFile [file join [srcdir] scripts dev makedist]  \
-                    [list {wget http://pear.php.net/install-pear-nozlib.phar -nd -P pear/} {ls pear/install-pear-nozlib.phar}]
+                    [list {wget https://pear.php.net/install-pear-nozlib.phar -nd -P pear/} {ls pear/install-pear-nozlib.phar}]
             }
 
             showEnvironmentVars

--- a/src/xamppstacks.tcl
+++ b/src/xamppstacks.tcl
@@ -1,4 +1,4 @@
-::itcl::class linuxXamppInstallerStack {
+::itcl::class linuxXamppInstallerCoreStack {
     inherit stack
     public variable pearModulesList {}
        constructor {environment} {
@@ -97,7 +97,7 @@
 }
 
 ::itcl::class linuxXamppInstallerXStack {
-    inherit linuxXamppInstallerStack
+    inherit linuxXamppInstallerCoreStack
     constructor {environment} {
         chain $environment
     } {
@@ -179,11 +179,19 @@
 
 
 ::itcl::class linuxXamppInstaller85Stack {
-    inherit linuxXamppInstaller83Stack
+    inherit linuxXamppInstaller84Stack
     constructor {environment} {
         chain $environment
     } {
-        replaceComponent ::xampp::php83 ::xampp::php85
+        replaceComponent ::xampp::php84 ::xampp::php85
+    }
+}
+
+::itcl::class linuxXamppInstallerStack {
+    inherit linuxXamppInstaller85Stack
+    constructor {environment} {
+        chain $environment
+    } {
     }
 }
 
@@ -387,7 +395,7 @@
     } {
         set fullname XAMPP
         set name xampp
-        set version [::xampp::php::getXAMPPVersion 55]
+        set version [::xampp::php::getXAMPPVersion 85]
         set projectFile xampp-installer-standalone.xml
         set programming_language PHP
         lappend tags MySQL Apache PHP Tomcat
@@ -882,8 +890,8 @@ return
         $targetInstance configure -kind portable
         set fullname "XAMPP Portable Lite"
         set name xampp
-        set version [::xampp::php::getXAMPPVersion 55]
-        set rev [::xampp::php::getXAMPPRevision 55]
+        set version [::xampp::php::getXAMPPVersion 85]
+        set rev [::xampp::php::getXAMPPRevision 85]
         set projectFile xampp-installer-portable-standalone.xml
         set programming_language PHP
         lappend tags MySQL Apache PHP Tomcat

--- a/src/xamppwindows.tcl
+++ b/src/xamppwindows.tcl
@@ -514,7 +514,7 @@
     } {
         set name windowsXamppMariaDb
         set fullname MariaDB
-        set version [versions::get "MariaDB" "10"]
+        set version [versions::get "MariaDB" "12"]
         set tarballName mariadb-${version}-win32.zip
         set pathName mariadb-${version}-win32
     }
@@ -659,7 +659,7 @@
     } {
         set name windowsXamppPhp
         set fullname PHP
-        set version [::xampp::php::getXAMPPVersion 55]
+        set version [::xampp::php::getXAMPPVersion 74]
         set vcVersion VC11
         set opensslVersion 1.0.2j
         set licenseRelativePath {}
@@ -1064,8 +1064,8 @@ mssql.secure_connection=Off"
         chain $environment
     } {
         set name xampp
-        set version [::xampp::php::getXAMPPVersion 55]
-        set rev [::xampp::php::getXAMPPRevision 55]
+        set version [::xampp::php::getXAMPPVersion 74]
+        set rev [::xampp::php::getXAMPPRevision 74]
         set licenseRelativePath {}
         set tarballName {}
     }
@@ -1273,8 +1273,8 @@ mssql.secure_connection=Off"
         chain $environment
     } {
         set name xampp
-        set version [::xampp::php::getXAMPPVersion 55]
-        set rev [::xampp::php::getXAMPPRevision 55]
+        set version [::xampp::php::getXAMPPVersion 74]
+        set rev [::xampp::php::getXAMPPRevision 74]
         set licenseRelativePath {}
         set tarballName {}
         #set dependencies {xampp {xampp.xml}}

--- a/src/xamppwindows64.tcl
+++ b/src/xamppwindows64.tcl
@@ -203,7 +203,7 @@
     } {
         set name windows64XamppMariaDb
         set fullname MariaDB
-        set version [versions::get "MariaDB" "10"]
+        set version [versions::get "MariaDB" "12"]
         set tarballName mariadb-${version}-winx64.zip
         set pathName mariadb-${version}-winx64
         lappend additionalFileList vcruntime140_1.dll
@@ -251,7 +251,7 @@
     } {
         set name windows64XamppPhp
         set fullname PHP
-        set version [::xampp::php::getXAMPPVersion 55]
+        set version [::xampp::php::getXAMPPVersion 74]
         set vcVersion VC11
         set opensslVersion 1.0.2j
         set licenseRelativePath {}
@@ -549,39 +549,6 @@
     }
 }
 
-::itcl::class windows64XamppInstallerStack {
-    inherit stack
-       constructor {environment} {
-        chain $environment
-    } {
-	addComponents bitnamiFiles nativeadapter windowsXamppWorkspace \
-	    windowsXamppHtdocs \
-	    windows64XamppVcredist \
-	    windows64XamppApache \
-	    windowsXamppApacheAddons \
-	    windowsXamppFileZillaFTP \
-	    windowsXamppFileZillaFTPSource \
-	    windowsXamppMercuryMail \
-	    windowsXamppMercuryMailAddons \
-	    windowsXamppSendmail \
-	    windows64XamppMariaDb \
-	    windowsXamppMysqlData \
-	    windows64XamppPerl \
-	    windowsXamppPerlAddons \
-	    windows64XamppPhp \
-	    windows64XamppPhpAddons \
-	    windows64XamppPhpXdebug \
-	    windowsXamppPhpPear \
-	    windowsXamppPhpADODB \
-	    windowsXamppPhpMyAdmin \
-	    windows64XamppCurl \
-	    windows64XamppTomcat \
-	    windowsXamppWebalizer \
-	    windowsXamppWebalizerAddons \
-	    windowsXamppStandard
-    }
-}
-
 ::itcl::class windows64XamppInstallerPhp74Stack {
     inherit stack
        constructor {environment} {
@@ -783,6 +750,14 @@
            replaceComponent windows64XamppApachePhp84 windows64XamppApachePhp85
            replaceComponent windows64XamppPhp84 windows64XamppPhp85
            replaceComponent windowsXamppStandardPhp84 windowsXamppStandardPhp85
+    }
+}
+
+::itcl::class windows64XamppInstallerStack {
+    inherit windows64XamppInstallerPhp85Stack
+    constructor {environment} {
+        chain $environment
+    } {
     }
 }
 


### PR DESCRIPTION
Direct MariaDB metadata and Tcl clients to the 12.x series (12.2.2) and continue using 10.x and 11.x versions for backward compatibility. Increment PHP patch levels in the versions.ini file if new versions have been released.
Change the default Windows x64 installer stack to the PHP 8.5 package. Coordinate the default linuxXamppInstallerStack with the PHP 8.5 dependency order by changing linuxXamppInstallerCoreStack and correcting 85 to depend on 84. Update the product installer metadata to PHP 8.5 and fix broken getXAMPPVersion 55 lookups in Windows helper files.
Update the following third-party pinning packages for enhanced security: Apache 2.4.66, OpenSSL 3.5.6, curl 8.19.0, SQLite 3.51.3, Git 2.54.0. Securely access MySQL, OpenSSL, PEAR, and SQLite related downloads