### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/src/xamppwindows.tcl
+++ b/src/xamppwindows.tcl
@@ -1437,6 +1437,16 @@ mssql.secure_connection=Off"
     }
 }
 
+::itcl::class windowsXamppPortablePhp83 {
+    inherit windowsXamppPortablePhp8
+    constructor {environment} {
+        chain $environment
+        set version [::xampp::php::getXAMPPVersion 83]
+        set rev [::xampp::php::getXAMPPRevision 83]
+    } {
+    }
+}
+
 ::itcl::class windowsXamppInstallerStack {
     inherit stack
        constructor {environment} {

--- a/src/xamppwindows64.tcl
+++ b/src/xamppwindows64.tcl
@@ -918,3 +918,28 @@
 	    windowsXamppPortablePhp82
     }
 }
+::itcl::class windows64XamppPortableInstallerPhp83Stack {
+    inherit stack
+       constructor {environment} {
+        chain $environment
+    } {
+	addComponents bitnamiFiles nativeadapter windowsXamppWorkspace \
+	    windowsXamppHtdocs \
+	    windows64XamppVcredist2019 \
+	    windows64XamppApachePhp83 \
+	    windowsXamppApacheAddons \
+	    windowsXamppSendmail \
+	    windows64XamppMariaDb \
+	    windowsXamppMysqlData \
+	    windows64XamppPerl \
+	    windowsXamppPerlAddons \
+	    windows64XamppPhp83 \
+	    windowsXamppPhpAddons \
+	    windowsXamppPhpPear \
+	    windowsXamppPhpADODB \
+	    windowsXamppPhpMyAdmin \
+	    windows64XamppCurl \
+	    windows64XamppTomcat \
+	    windowsXamppPortablePhp83
+    }
+}


### PR DESCRIPTION
I added support for PHP 8.3 and successfully built the Docker image using:

```
docker build . -t xampp-build
```
However, I noticed that the documentation refers to a folder named ../xampp-code:

```
docker run -v `pwd`/../xampp-code:/home/xampp-code \
           -v `pwd`/tarballs:/tmp/tarballs \
           -it xampp-build bash
```

I could not find any repository named xampp-code in the ApacheFriends organization.
Could you clarify where the actual XAMPP source code is expected to come from, or how the xampp-code directory should be prepared?